### PR TITLE
Add initial CMakeLists with googletest and abseil external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Directories:
 - `fortran`: Fortran wrappers for the WFDB library.
 - `wave`: The Linux desktop waveform viewer, WAVE.
 
-## Installation
+## Building and Installing
 
 WFDB is officially supported on Linux.
 
@@ -25,7 +25,11 @@ Eg. For Debian and Ubuntu:
 ```sh
 sudo apt-get update && sudo apt-get install -y gcc curl cmake
 
-# TODO after cmake integration
+cd src
+# Create the build artifacts
+cmake -S . -b build
+# Compile the code
+cmake --build build
 
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(WFDB VERSION 20.0.0)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# External dependencies.
+# Example instructions: https://github.com/google/googletest/blob/main/googletest/README.md#incorporating-into-an-existing-cmake-project
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.11.0
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+FetchContent_Declare(
+  abseil
+  GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+  GIT_TAG 20211102.0
+)
+# Usage instructions: https://github.com/abseil/abseil-cpp/blob/master/CMake/README.md
+FetchContent_MakeAvailable(abseil)
+
+add_subdirectory(lib)


### PR DESCRIPTION
Test library/framework:
- https://github.com/google/googletest

Utility library, very useful for strings, command line flags, and more.
- https://github.com/abseil/abseil-cpp
- https://abseil.io/docs/cpp/