### PR TITLE
Remove code used to support old systems

### DIFF
--- a/src/lib/wfdb.h
+++ b/src/lib/wfdb.h
@@ -37,38 +37,6 @@ _______________________________________________________________________________
      */
 #define WFDB_NETFILES_LIBCURL 1
 
-/* Determine what type of compiler is being used. */
-#ifdef __STDC__    /* true for ANSI C compilers only */
-#define wfdb_PROTO /* function prototypes will be needed */
-#undef _WINDOWS    /* we don't want MS-Windows API in this case */
-#endif
-
-#ifdef __cplusplus /* true for some C++ compilers */
-#define wfdb_CPP
-#define wfdb_PROTO
-#endif
-
-#ifdef c_plusplus /* true for some other C++ compilers */
-#define wfdb_CPP
-#define wfdb_PROTO
-#endif
-
-#ifdef _WIN32 /* true when compiling for 32-bit MS Windows */
-#ifndef _WINDOWS
-#define _WINDOWS
-#endif
-#endif
-
-#ifdef _WINDOWS /* true when compiling for MS Windows */
-#define wfdb_PROTO
-#endif
-
-#ifndef wfdb_PROTO /* should be true for K&R C compilers only */
-#define wfdb_KRC
-#define signed
-#undef WFDB_LARGETIME
-#endif
-
 /* Simple data types */
 typedef int WFDB_Sample;             /* units are adus */
 typedef long WFDB_Date;              /* units are days */
@@ -100,29 +68,11 @@ typedef unsigned int WFDB_Annotator; /* annotator number */
 /* The 'WFDB_Time' type is traditionally defined as a long integer.
    However, if the preprocessor symbol WFDB_LARGETIME is defined prior
    to including this file, it is defined as a 'long long' instead. */
-#ifndef WFDB_LARGETIME
-typedef long WFDB_Time; /* units are sample intervals */
-#define WFDB_TIME_MIN LONG_MIN
-#define WFDB_TIME_MAX LONG_MAX
-#define WFDB_TIME_PRINTF_MODIFIER "l"
-#define WFDB_TIME_SCANF_MODIFIER "l"
-#else
-#if defined(_MSC_VER) && _MSC_VER < 1400
-typedef __int64 WFDB_Time;
-#define WFDB_TIME_MIN _I64_MIN
-#define WFDB_TIME_MAX _I64_MAX
-#else
 typedef long long WFDB_Time;
 #define WFDB_TIME_MIN LLONG_MIN
 #define WFDB_TIME_MAX LLONG_MAX
-#endif
-#ifdef _WIN32
-#define WFDB_TIME_PRINTF_MODIFIER "I64"
-#define WFDB_TIME_SCANF_MODIFIER "I64"
-#else
 #define WFDB_TIME_PRINTF_MODIFIER "ll"
 #define WFDB_TIME_SCANF_MODIFIER "ll"
-#endif
 
 /* A number of WFDB library functions use WFDB_Time as either a
    parameter or return value, so the library includes two versions of
@@ -140,7 +90,6 @@ typedef long long WFDB_Time;
 #define ungetann wfdb_ungetann_LL
 #define putann wfdb_putann_LL
 #define getseginfo wfdb_getseginfo_LL
-#endif
 
 /* The following macros can be used to construct format strings for
    printf and scanf, and related standard library functions. */
@@ -369,7 +318,6 @@ typedef struct WFDB_seginfo WFDB_Seginfo;
   } while (0)
 
 /* Function types */
-#ifndef _WINDLL /* for everything *except* MS Windows applications */
 typedef char *FSTRING;
 typedef const char *FCONSTSTRING;
 typedef WFDB_Date FDATE;
@@ -380,43 +328,8 @@ typedef long FLONGINT;
 typedef WFDB_Sample FSAMPLE;
 typedef WFDB_Time FSITIME;
 typedef void FVOID;
-#else
-#ifndef _WIN32 /* for 16-bit MS Windows applications using the WFDB DLL */
-/* typedefs don't work properly with _far or _pascal -- must use #defines */
-#define FSTRING char _far *_pascal
-#define FCONSTSTRING const char _far *_pascal
-#define FDATE WFDB_Date _far _pascal
-#define FDOUBLE double _far _pascal
-#define FFREQUENCY WFDB_Frequency _far _pascal
-#define FINT int _far _pascal
-#define FLONGINT long _far _pascal
-#define FSAMPLE WFDB_Sample _far _pascal
-#define FSITIME WFDB_Time _far _pascal
-#define FVOID void _far _pascal
-#else /* for 32-bit MS Windows applications using the WFDB DLL */
-#ifndef CALLBACK
-#define CALLBACK __stdcall /* from windef.h */
-#endif
-#define FSTRING __declspec(dllexport) char *CALLBACK
-#define FCONSTSTRING __declspec(dllexport) const char *CALLBACK
-#define FDATE __declspec(dllexport) WFDB_Date CALLBACK
-#define FDOUBLE __declspec(dllexport) double CALLBACK
-#define FFREQUENCY __declspec(dllexport) WFDB_Frequency CALLBACK
-#define FINT __declspec(dllexport) int CALLBACK
-#define FLONGINT __declspec(dllexport) long CALLBACK
-#define FSAMPLE __declspec(dllexport) WFDB_Sample CALLBACK
-#define FSITIME __declspec(dllexport) WFDB_Time CALLBACK
-#define FVOID __declspec(dllexport) void CALLBACK
-#endif
-#endif
 
-/* Specify C linkage for C++ compilers. */
-#ifdef wfdb_CPP
-extern "C" {
-#endif
-
-/* Define function prototypes for ANSI C compilers and C++ compilers */
-#ifdef wfdb_PROTO
+/* Define function prototypes */
 extern FINT annopen(char *record, const WFDB_Anninfo *aiarray,
                     unsigned int nann);
 extern FINT isigopen(char *record, WFDB_Siginfo *siarray, int nsig);
@@ -520,9 +433,7 @@ extern FINT setobsize(int output_buffer_size);
 extern FSTRING wfdbfile(const char *file_type, char *record);
 extern FVOID wfdbflush(void);
 extern FVOID wfdbmemerr(int exit_on_error);
-#if __GNUC__ >= 3
 __attribute__((__format__(__printf__, 1, 2)))
-#endif
 extern FVOID
 wfdb_error(const char *format_string, ...);
 extern FINT wfdb_me_fatal(void);
@@ -531,84 +442,5 @@ extern FCONSTSTRING wfdbldflags(void);
 extern FCONSTSTRING wfdbcflags(void);
 extern FCONSTSTRING wfdbdefwfdb(void);
 extern FCONSTSTRING wfdbdefwfdbcal(void);
-#endif
-
-#ifdef wfdb_CPP
-}
-#endif
-
-#ifdef wfdb_KRC /* declare only function return types for K&R C compilers */
-extern FINT annopen(), isigopen(), osigopen(), wfdbinit(), findsig(), getspf(),
-    setifreq(), getvec(), getframe(), getgvmode(), putvec(), getann(),
-    ungetann(), putann(), isigsettime(), isgsettime(), iannsettime(), strecg(),
-    setecgstr(), strann(), setannstr(), setanndesc(), wfdb_isann(),
-    wfdb_isqrs(), wfdb_setisqrs(), wfdb_map1(), wfdb_setmap1(), wfdb_map2(),
-    wfdb_setmap2(), wfdb_ammap(), wfdb_mamap(), wfdb_annpos(), wfdb_setannpos(),
-    adumuv(), newheader(), setheader(), setmsheader(), getseginfo(),
-    wfdbputprolog(), setsampfreq(), setbasetime(), putinfo(), setinfo(),
-    setibsize(), setobsize(), calopen(), getcal(), putcal(), newcal(),
-    wfdbgetskew(), sample_valid(), wfdb_me_fatal();
-extern FLONGINT wfdbgetstart();
-extern FSAMPLE muvadu(), physadu(), sample();
-extern FSTRING ecgstr(), annstr(), anndesc(), timstr(), mstimstr(), datstr(),
-    getwfdb(), getinfo(), wfdberror(), wfdbfile();
-extern FSITIME strtim(), tnextvec();
-extern FDATE strdat();
-extern FVOID setafreq(), setgvmode(), wfdb_freeinfo(), wfdbquit(), wfdbquiet(),
-    wfdbverbose(), setdb(), wfdbflush(), setcfreq(), setbasecount(), flushcal(),
-    wfdbsetiskew(), wfdbsetskew(), wfdbsetstart(), wfdbmemerr(), wfdb_error(),
-    setiafreq();
-extern FFREQUENCY getafreq(), getifreq(), sampfreq(), getcfreq(), getiafreq(),
-    getiaorigfreq();
-extern FDOUBLE aduphys(), getbasecount();
-#endif
-
-/* Remove local preprocessor definitions. */
-#ifdef wfdb_PROTO
-#undef wfdb_PROTO
-#endif
-
-#ifdef wfdb_CPP
-#undef wfdb_CPP
-#endif
-
-#ifdef wfdb_KRC
-#undef wfdb_KRC
-#undef signed
-#endif
-
-/* Include some useful function declarations.  This section includes standard
-   header files if available and provides alternative declarations for those
-   platforms that need them.
-
-  The ANSI/ISO C standard requires conforming compilers to predefine __STDC__.
-  Non-conforming compilers for MS-Windows may or may not predefine _WINDOWS;
-  if you use such a compiler, you may need to define _WINDOWS manually. */
-#if defined(__STDC__) || defined(_WINDOWS)
-#include <stdlib.h>
-#else
-extern char *getenv();
-extern void exit();
-typedef long time_t;
-#ifdef HAVE_MALLOC_H
-#include <malloc.h>
-#else
-extern char *malloc(), *calloc(), *realloc();
-#endif
-#ifdef ISPRINTF
-extern int sprintf();
-#else
-#ifndef MSDOS
-extern char *sprintf();
-#endif
-#endif
-#endif
-
-#ifndef BSD
-#include <string.h>
-#else /* for Berkeley UNIX only */
-#include <strings.h>
-#define strchr index
-#endif
 
 #endif

--- a/src/lib/wfdbio.cc
+++ b/src/lib/wfdbio.cc
@@ -155,6 +155,8 @@ obtained if necessary by defining the symbol NOSTRTOK when compiling this
 module.
 */
 
+#include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #include "wfdblib.h"

--- a/src/lib/wfdblib.h
+++ b/src/lib/wfdblib.h
@@ -32,65 +32,6 @@ symbols reserved to the library begin with the characters "wfdb_".
 
 #include "wfdb.h"
 
-/* MS-Windows users are strongly advised to compile the WFDB library using the
-   free Cygwin tools (www.cygwin.com).  Use of other compilers may be possible
-   but is not supported.
-
-   Cygwin users:  Note that the symbols _WINDOWS, _WINDLL, WIN32, etc. are
-   not defined and should not be defined when compiling the WFDB software
-   package using gcc.  Cygwin's POSIX emulation layer avoids the need for
-   the various workarounds required when using other compilers under
-   MS-Windows.
-
-   If you are using another MS-Windows compiler, you will need these
-   workarounds, and you should be careful to define _WINDOWS, _WINDLL, and
-   _WIN32 as appropriate.  Older versions of the WFDB library were successfully
-   compiled under MS-DOS and under 16-bit versions of MS-Windows, but the
-   conditionally compiled code written to support these platforms has not been
-   tested recently.
-
-   Define the symbol _WINDLL if this library is to be compiled as a Microsoft
-   Windows DLL.  Note that a DLL's private functions (such as those listed
-   below) *cannot* be called by Windows user programs, which can call only DLL
-   functions that use the Pascal calling interface (see wfdb.h).  To compile
-   this library for use in a Microsoft Windows application, but *not* as a DLL,
-   define the symbol _WINDOWS instead of _WINDLL. */
-/* #define _WINDLL */
-
-#if defined(_WINDLL) && !defined(_WINDOWS)
-#define _WINDOWS
-#endif
-
-#if defined(_WIN16) && !defined(_WINDOWS)
-#define _WINDOWS
-#endif
-
-#if defined(_WIN32) && !defined(_WINDOWS)
-#define _WINDOWS
-#endif
-
-#if defined(_WINDOWS) && !defined(_WIN16) && !defined(_WIN32)
-#define _WIN16
-#endif
-
-/* Define the symbol MSDOS if this library is to be used under MS-DOS or MS
-   Windows.  Note: MSDOS is predefined by some MS-DOS and MS Windows compilers.
-*/
-#if defined(_WINDOWS)
-#if !defined(MSDOS)
-#define MSDOS
-#endif
-#endif
-
-/* Macintosh users are strongly advised to use Mac OS X or later.  If you are
-   doing so, no special configuration is needed, and you may ignore this
-   section.
-
-   If you are running Mac OS 9 or earlier, you may be able to use the WFDB
-   software package, but this configuration has not been tested for many years,
-   and is not supported!  If you would like to try it, define MAC. */
-/* #define MAC */
-
 /* DEFWFDB is the default value of the WFDB path if the WFDB environment
    variable is not set.  This value is edited by the configuration script
    (../configure), which also edits this block of comments to match.
@@ -111,27 +52,6 @@ symbols reserved to the library begin with the characters "wfdb_".
 #define DEFWFDB ". DBDIR http://physionet.org/physiobank/database"
 #endif
 
-/* Mac OS 9 and earlier, only:  The value of DEFWFDB given below specifies
-   that the WFDB path is to be read from the file udb/dbpath.mac on the third
-   edition of the MIT-BIH Arrhythmia Database CD-ROM (which has a volume name
-   of `MITADB3');  you may prefer to use a file on a writable disk for this
-   purpose, to make reconfiguration possible.  See getwfdb() in wfdbio.c for
-   further information.
-
-   If the version of "ISO 9660 File Access" in the "System:Extensions" folder
-   is earlier than 5.0, either update your system software (recommended) or
-   define FIXISOCD. */
-
-#ifdef MAC
-/* #define FIXISOCD */
-#ifdef FIXISOCD
-#define DEFWFDB "@MITADB3:UDB:DBPATH.MAC;1"
-#else
-#define DEFWFDB "@MITADB3:UDB:DBPATH.MAC"
-#define __STDC__
-#endif
-#endif
-
 /* DEFWFDBCAL is the name of the default WFDB calibration file, used if the
    WFDBCAL environment variable is not set.  This name need not include path
    information if the calibration file is located in a directory included in
@@ -149,11 +69,9 @@ symbols reserved to the library begin with the characters "wfdb_".
    DEFWFDBANNSORT is non-zero).  Sorting is done by invoking 'sortann' (see
    ../app/sortann.c) as a separate process;  since this cannot be done from
    an MS-Windows DLL, sorting is disabled by default in this case. */
-#if defined(_WINDLL)
-#define DEFWFDBANNSORT 0
-#else
+
+// TODO(cx1111): Remove the need for this variable
 #define DEFWFDBANNSORT 1
-#endif
 
 /* When reading multifrequency records, getvec() can operate in two modes:
    WFDB_LOWRES (returning one sample per signal per frame), or WFDB_HIGHRES
@@ -164,32 +82,11 @@ symbols reserved to the library begin with the characters "wfdb_".
    is not set, the value of DEFWFDBMODE determines the mode. */
 #define DEFWFDBGVMODE WFDB_LOWRES
 
-/* putenv() is available in POSIX, SVID, and BSD Unices and in MS-DOS and
-   32-bit MS Windows, but not under 16-bit MS Windows or under MacOS.  If it is
-   available, getwfdb() (in wfdbio.c) detects when the environment variables
-   WFDB, WFDBCAL, WFDBANNSORT, and WFDBGVMODE are not set, and sets them
-   according to DEFWFDB, DEFWFDBCAL, DEFWFDBANNSORT, and DEFWFDBGVMODE as
-   needed using putenv().  This feature is useful mainly for programs such as
-   WAVE, where these variables are set interactively and it is useful to show
-   their default values to the user; setwfdb() and getwfdb() do not depend on
-   it.
-*/
-#if !defined(_WIN16) && !defined(MAC)
+// TODO(cx1111): Remove the need for this variable
 #define HAS_PUTENV
-#endif
 
 #ifndef FILE
 #include <stdio.h>
-/* stdin/stdout may not be defined in some environments (e.g., for MS Windows
-   DLLs).  Defining them as NULL here allows the WFDB library to be compiled in
-   such environments (it does not allow use of stdin/stdout when the operating
-   environment does not provide them, however). */
-#ifndef stdin
-#define stdin NULL
-#endif
-#ifndef stdout
-#define stdout NULL
-#endif
 #endif
 
 #ifndef TRUE
@@ -254,36 +151,9 @@ typedef struct WFDB_FILE WFDB_FILE;
 
 #endif
 
-#ifdef _WINDOWS
-#ifndef _WIN32 /* these definitions are needed for 16-bit MS Windows only */
-#define strcat _fstrcat
-#define strchr _fstrchr
-#define strcmp _fstrcmp
-#define strcpy _fstrcpy
-#define strlen _fstrlen
-#define strncmp _fstrncmp
-#define strtok _fstrtok
-#endif
-#endif
-
-/* Define MKDIR as either the one-argument mkdir() (for the native MSDOS and
-   MS-Windows API) or the standard two-argument mkdir() (everywhere else). */
-#ifndef MKDIR
-#ifdef MSDOS
-#include <direct.h>
-#define MKDIR(D, P) mkdir((D))
-#else
 #include <sys/stat.h>
 #define MKDIR(D, P) mkdir((D), (P))
-#endif
-#endif
 
-/* Define function prototypes for ANSI C, MS Windows C, and C++ compilers */
-#if defined(__STDC__) || defined(__cplusplus) || defined(c_plusplus) || \
-    defined(_WINDOWS)
-#if defined(__cplusplus) || defined(c_plusplus)
-extern "C" {
-#endif
 
 /* These functions are defined in wfdbio.c */
 extern int wfdb_fclose(WFDB_FILE *fp);
@@ -297,20 +167,12 @@ extern void wfdb_p16(unsigned int x, WFDB_FILE *fp);
 extern void wfdb_p32(long x, WFDB_FILE *fp);
 extern int wfdb_parse_path(const char *wfdb_path);
 extern void wfdb_addtopath(const char *pathname);
-#if __GNUC__ >= 3
 __attribute__((__format__(__printf__, 2, 3)))
-#endif
-extern int
-wfdb_asprintf(char **buffer, const char *format, ...);
+extern int wfdb_asprintf(char **buffer, const char *format, ...);
 extern WFDB_FILE *wfdb_fopen(char *fname, const char *mode);
-#if __GNUC__ >= 3
-__attribute__((__format__(__printf__, 2, 3)))
-#endif
-extern int
-wfdb_fprintf(WFDB_FILE *fp, const char *format, ...);
+extern int wfdb_fprintf(WFDB_FILE *fp, const char *format, ...);
 extern void wfdb_setirec(const char *record_name);
 extern char *wfdb_getirec(void);
-
 extern void wfdb_clearerr(WFDB_FILE *fp);
 extern int wfdb_feof(WFDB_FILE *fp);
 extern int wfdb_ferror(WFDB_FILE *fp);
@@ -334,33 +196,3 @@ extern int wfdb_oinfoclose(void);
 /* These functions are defined in annot.c */
 extern void wfdb_anclose(void);
 extern void wfdb_oaflush(void);
-
-#if defined(__cplusplus) || defined(c_plusplus)
-}
-#endif
-
-#else /* declare only function return types for non-ANSI C compilers */
-
-extern char *wfdb_getirec();
-extern int wfdb_fclose(), wfdb_checkname(), wfdb_g16(), wfdb_parse_path(),
-    wfdb_fprintf();
-extern long wfdb_g32();
-extern void wfdb_striphea(), wfdb_p16(), wfdb_p32(), wfdb_addtopath(),
-    wfdb_setirec(), wfdb_sampquit(), wfdb_sigclose(), wfdb_osflush(),
-    wfdb_freeinfo(), wfdb_oinfoclose(), wfdb_anclose(), wfdb_oaflush();
-extern WFDB_FILE *wfdb_open(), *wfdb_fopen();
-
-extern char *wfdb_fgets();
-extern int wfdb_feof(), wfdb_ferror(), wfdb_fflush(), wfdb_fseek(), wfdb_getc(),
-    wfdb_putc();
-extern long wfdb_ftell();
-extern size_t wfdb_fread(), wfdb_fwrite();
-extern void wfdb_clearerr();
-
-/* Some non-ANSI C libraries (e.g., version 7, BSD 4.2) lack an implementation
-   of strtok(); define NOSTRTOK to compile the portable version in wfdbio.c. */
-#ifdef NOSTRTOK
-extern char *strtok();
-#endif
-
-#endif


### PR DESCRIPTION
Remove code used to support old systems: MS-DOS, 16 bit systems, FreeBSD.

Also remove C-only code. The codebase will be C++.