### PR TITLE
Reorg of wfdb and netfiles library contents

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,2 @@
 Language: Cpp
 BasedOnStyle: Google
-LanguageStandard: LS_Cpp20

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(Wfdb wfdb.cc)
+
+target_link_libraries(Wfdb absl::strings)

--- a/src/lib/netfiles.cc
+++ b/src/lib/netfiles.cc
@@ -1,4 +1,5 @@
 #include "netfiles.hh"
+#include "wfdb.hh"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -234,7 +235,7 @@ Netfile *nf_new(const char *url) {
   Netfile *nf;
   Chunk *chunk = NULL;
 
-  SUALLOC(nf, 1, sizeof(netfile));
+  SUALLOC(nf, 1, sizeof(Netfile));
   if (nf && url && *url) {
     SSTRCPY(nf->url, url);
     nf->base_addr = 0;

--- a/src/lib/netfiles.hh
+++ b/src/lib/netfiles.hh
@@ -3,10 +3,17 @@
 
 #include <curl/curl.h>
 
+#include <string>
+
+enum class NetfileMode {
+  kChunkMode = 0, /* http range requests supported */
+  kFullMode = 1,  /* http range requests not supported */
+};
+
 struct Netfile {
   char *url;
   char *data;
-  int mode;
+  NetfileMode mode;
   long base_addr;
   long cont_len;
   long pos;
@@ -42,10 +49,6 @@ struct Chunk {
 #define NF_NO_ERR 0   /* no errors */
 #define NF_EOF_ERR 1  /* file pointer at EOF */
 #define NF_REAL_ERR 2 /* read request failed */
-
-/* values for Netfile 'mode' field */
-#define NF_CHUNK_MODE 0 /* http range requests supported */
-#define NF_FULL_MODE 1  /* http range requests not supported */
 
 /* The next group of functions, which enable input from remote
 (http and ftp) files, were first implemented in version 10.0.1 by Michael
@@ -113,7 +116,7 @@ int nf_putc(int c, Netfile *nf);
 // emulates fprintf, for netfiles) [stub]
 int nf_vfprintf(Netfile *nf, const char *format, va_list ap);
 
-char *curl_get_ua_string();
+std::string curl_get_ua_string();
 int curl_try(CURLcode err);
 unsigned int www_time();
 size_t curl_null_write(void *ptr, size_t size, size_t nmemb, void *stream);

--- a/src/lib/netfiles.hh
+++ b/src/lib/netfiles.hh
@@ -24,18 +24,14 @@ struct Netfile {
 };
 
 struct Chunk {
-  long size, buffer_size;
-  unsigned long start_pos, end_pos, total_size;
+  long size;
+  long buffer_size;
+  unsigned long start_pos;
+  unsigned long end_pos;
+  unsigned long total_size;
   char *data;
   char *url;
 };
-
-// Constants/Config
-
-/* cache redirections for 5 minutes */
-#define REDIRECT_CACHE_TIME (5 * 60)
-
-#define NF_PAGE_SIZE 32768 /* default bytes per http range request */
 
 #ifndef EROFS /* errno value: attempt to write to a read-only file system */
 #ifdef EINVAL

--- a/src/lib/wfdb.cc
+++ b/src/lib/wfdb.cc
@@ -1,0 +1,44 @@
+#include "wfdb.hh"
+
+#include <absl/strings/str_format.h>
+
+#include <iostream>
+#include <string>
+
+// Error tracking state
+static std::string error_message =
+    absl::StrFormat("WFDB library version %d.%d.%d (%s).\n", WFDB_MAJOR,
+                    WFDB_MINOR, WFDB_RELEASE, WFDB_BUILD_DATE);
+static bool print_error = true;
+
+/* Handles error messages, normally by printing them on the standard error
+output. It can be silenced by invoking wfdbquiet(), or re-enabled by invoking
+wfdbverbose().
+*/
+void wfdb_error(std::string_view msg) {
+  error_message = msg;
+
+  if (print_error) {
+    std::cerr << error_message << std::flush;
+  }
+}
+
+/*
+Returns the most recent error message passed to wfdb_error (even if output was
+suppressed by wfdbquiet). This feature permits programs to handle errors
+somewhat more flexibly (in windowing environments, for example, where using the
+standard error output may be inappropriate).
+*/
+std::string wfdberror() {
+  // TODO: Figure out memory strategy
+  if (error_message.empty()) {
+    return "WFDB: cannot allocate memory for error message";
+  }
+  return error_message;
+}
+
+/* wfdbquiet can be used to suppress error messages from the WFDB library. */
+void wfdbquiet() { print_error = false; }
+
+/* wfdbverbose enables error messages from the WFDB library. */
+void wfdbverbose() { print_error = true; }

--- a/src/lib/wfdb.hh
+++ b/src/lib/wfdb.hh
@@ -6,11 +6,18 @@ WFDB library type, constant, structure, and function interface definitions
 #ifndef WFDB_LIB_WFDB_H_
 #define WFDB_LIB_WFDB_H_
 
+#include <string>
+
+#ifndef WFDB_BUILD_DATE
+#define WFDB_BUILD_DATE __DATE__
+#endif
+
 /* WFDB library version. */
-constexpr char* WFDB_MAJOR = "20";
-constexpr char* WFDB_MINOR = "0";
-constexpr char* WFDB_RELEASE = "0";
-constexpr int WFDB_NETFILES = 1; /* if 1, library includes code for HTTP, FTP clients */
+constexpr char *WFDB_MAJOR = "20";
+constexpr char *WFDB_MINOR = "0";
+constexpr char *WFDB_RELEASE = "0";
+constexpr int WFDB_NETFILES =
+    1; /* if 1, library includes code for HTTP, FTP clients */
 
 /* Simple data types */
 typedef int WFDB_Sample;             /* units are adus */
@@ -274,5 +281,14 @@ typedef struct WFDB_seginfo WFDB_Seginfo;
       strcpy(P, WFDB_tmp);                        \
     }                                             \
   } while (0)
+
+// Produces an error message
+void wfdb_error(std::string_view);
+// Produces the last error message
+std::string wfdberror();
+// Suppresses WFDB library error messages
+void wfdbquiet();
+// Enables WFDB library error messages
+void wfdbverbose();
 
 #endif  // WFDB_LIB_WFDB_H_

--- a/src/lib/wfdb.hh
+++ b/src/lib/wfdb.hh
@@ -13,9 +13,9 @@ WFDB library type, constant, structure, and function interface definitions
 #endif
 
 /* WFDB library version. */
-constexpr char *WFDB_MAJOR = "20";
-constexpr char *WFDB_MINOR = "0";
-constexpr char *WFDB_RELEASE = "0";
+constexpr char WFDB_MAJOR[] = "20";
+constexpr char WFDB_MINOR[] = "0";
+constexpr char WFDB_RELEASE[] = "0";
 constexpr int WFDB_NETFILES =
     1; /* if 1, library includes code for HTTP, FTP clients */
 

--- a/src/lib/wfdb.hh
+++ b/src/lib/wfdb.hh
@@ -1,4 +1,4 @@
-/* file: wfdb.h		G. Moody	13 June 1983
+/* file: wfdb.hh		G. Moody	13 June 1983
 
 WFDB library type, constant, structure, and function interface definitions
 

--- a/src/lib/wfdbio.cc
+++ b/src/lib/wfdbio.cc
@@ -592,51 +592,6 @@ int wfdb_asprintf(char **buffer, const char *format, ...) {
   return (length);
 }
 
-/* The wfdb_error function handles error messages, normally by printing them
-on the standard error output.  Its arguments can be any set of arguments which
-would be legal for printf, i.e., the first one is a format string, and any
-additional arguments are values to be filled into the '%*' placeholders
-in the format string.  It can be silenced by invoking wfdbquiet(), or
-re-enabled by invoking wfdbverbose().
-
-The function wfdberror (without the underscore) returns the most recent error
-message passed to wfdb_error (even if output was suppressed by wfdbquiet).
-This feature permits programs to handle errors somewhat more flexibly (in
-windowing environments, for example, where using the standard error output may
-be inappropriate).
-*/
-
-static int error_flag;
-static char *error_message;
-
-#ifndef WFDB_BUILD_DATE
-#define WFDB_BUILD_DATE __DATE__
-#endif
-
-char* wfdberror() {
-  if (!error_flag)
-    wfdb_asprintf(&error_message, "WFDB library version %d.%d.%d (%s).\n",
-                  WFDB_MAJOR, WFDB_MINOR, WFDB_RELEASE, WFDB_BUILD_DATE);
-  if (error_message)
-    return (error_message);
-  else
-    return ("WFDB: cannot allocate memory for error message");
-}
-
-void wfdb_error(const char *format, ...) {
-  va_list arguments;
-
-  error_flag = 1;
-  va_start(arguments, format);
-  wfdb_vasprintf(&error_message, format, arguments);
-  va_end(arguments);
-
-  if (error_print) {
-    (void)fprintf(stderr, "%s", wfdberror());
-    (void)fflush(stderr);
-  }
-}
-
 /* The wfdb_fprintf function handles all formatted output to files.  It is
 used in the same way as the standard fprintf function, except that its first
 argument is a pointer to a WFDB_FILE rather than a FILE. */

--- a/src/lib/wfdbio.hh
+++ b/src/lib/wfdbio.hh
@@ -86,10 +86,6 @@ char* getwfdb();
 void setwfdb(const char *database_path_string);
 // restores the database path to its initial value
 void resetwfdb();
-// Suppresses WFDB library error messages
-void wfdbquiet();
-// Enables WFDB library error messages
-void wfdbverbose();
 
 // Returns the complete pathname of a WFDB file
 char* wfdbfile(const char *file_type, char *record);
@@ -143,11 +139,6 @@ static const char *wfdb_getiwfdb(char **p);
 void wfdb_addtopath(const char *pathname);
 __attribute__((__format__(__printf__, 2, 3)))
 
-// Allocates and formats a message
-int wfdb_asprintf(char **buffer, const char *format, ...);
-// Allocates and formats a message
-int wfdb_vasprintf(char **buffer, const char *format, ...);
-
 // Like fprintf, but first arg is a WFDB_FILE pointer
 int wfdb_fprintf(WFDB_FILE *fp, const char *format, ...);
 // Saves current record name
@@ -155,10 +146,7 @@ void wfdb_setirec(const char *record_name);
 // Gets current record name
 char *wfdb_getirec();
 
-// Produces an error message
-void wfdb_error(const char *format, ...);
-// Produces an error message
-char* wfdberror();
+
 
 /* These functions are compiled only if WFDB_NETFILES is non-zero; they permit
 access to remote files via http or ftp (using libcurl) as


### PR DESCRIPTION
* More source file name changes: Add wfdb.cc to contain core definitions.
* Clean up error setting code. Remove printf format functions.
* Add a small CMakeLists build target
* Clean up a bunch of global state variables
* Play around with netfiles.cc.

Might plan to shelf netfiles for now. Thinking of replacing libcurl with https://github.com/libcpr/cpr which has C++ APIS and seems much easier to use.